### PR TITLE
Fix some makefile issues

### DIFF
--- a/sdl/Makefile.linux
+++ b/sdl/Makefile.linux
@@ -11,8 +11,8 @@ BASELIBDIR := lib64
 else
 BASELIBDIR := lib
 endif
-CFLAGS += -g $(shell PKG_CONFIG_PATH=/usr/$(BASELIBDIR)/pkgconfig pkg-config sdl --cflags) $(shell PKG_CONFIG_PATH=/usr/$(BASELIBDIR)/pkgconfig pkg-config gtk+-2.0 --cflags)
-LFLAGS += -lm -L/usr/$(BASELIBDIR) $(shell PKG_CONFIG_PATH=/usr/$(BASELIBDIR)/pkgconfig pkg-config sdl --libs) $(shell PKG_CONFIG_PATH=/usr/$(BASELIBDIR)/pkgconfig pkg-config gtk+-2.0 --libs) -lSDL_image -lSDL_ttf -lfreetype -lz -lX11
+CFLAGS += -g $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):/usr/$(BASELIBDIR)/pkgconfig pkg-config sdl --cflags) $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):/usr/$(BASELIBDIR)/pkgconfig pkg-config gtk+-2.0 --cflags)
+LFLAGS += -lm -L/usr/$(BASELIBDIR) $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):/usr/$(BASELIBDIR)/pkgconfig pkg-config sdl --libs) $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):/usr/$(BASELIBDIR)/pkgconfig pkg-config gtk+-2.0 --libs) -lSDL_image -lSDL_ttf -lfreetype -lz -lX11
 PREFIX = /usr
 
 CFLAGS += -I$(BASEDIR) \
@@ -45,11 +45,12 @@ clean:
 	rm $(OBJECTS) $(OBJECTS:.o=.d) $(TARGET)
 
 install:
-	mkdir -p $(PREFIX)/share/man/man1/
-	../docs/hivelytracker.1 $(PREFIX)/share/man/man1/
+	install -Dm644 ../Docs/hivelytracker.1 $(PREFIX)/share/man/man1/hivelytracker.1
 	gzip -9 $(PREFIX)/share/man/man1/hivelytracker.1
-	install -o root -g root -m 755 ../sdl/hivelytracker $(PREFIX)/bin
-	install -o root -g root -m 644 ../sdl/winicon.png $(PREFIX)/share/icons/hivelytracker.png
-	install -o root -g root -m 644 ../sdl/hivelytracker.desktop $(PREFIX)/share/applications
-	install -o root -g root -m 644 ../Instruments $(PREFIX)share/hivelytracker                                                                            
-	install -o root -g root -m 644 ../Skins $(PREFIX)/share/hivelytracker
+	install -Dm 755 ../sdl/hivelytracker $(PREFIX)/bin/hivelytracker
+	install -Dm 644 ../sdl/winicon.png $(PREFIX)/share/icons/hivelytracker.png
+	install -Dm 644 ../sdl/hivelytracker.desktop $(PREFIX)/share/applications/hivelytracker.desktop
+	mkdir $(PREFIX)/share/hivelytracker
+	cp -r ../Instruments $(PREFIX)/share/hivelytracker/Instruments
+	cp -r ../Skins $(PREFIX)/share/hivelytracker/Skins
+	cp -r ../ttf $(PREFIX)/share/hivelytracker/ttf


### PR DESCRIPTION
* Append paths to PKG_CONFIG_PATH instead of overwriting it
* Use slash after PREFIX (often PREFIX does not end with a slash)
* Install all files correctly

---

Hi! I'm packaging hivelytracker for NixOS and this is the makefile patch I had to apply to make the program install correctly. It'd be great if it'll be upstreamed!